### PR TITLE
[PEEPS-2446] SERVICE_API: Faraday should allow for query params to be masked/obfuscated when making requests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,10 @@
+language: ruby
+cache: bundler
+sudo: false
+install:
+  - bundle install
+rvm:
+  - 2.2.4
+  - 2.3.2
+script:
+  - "bundle exec rspec"

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "{}"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright 2016 Westfield Labs
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/README.md
+++ b/README.md
@@ -1,0 +1,49 @@
+# Faraday::LogFilter
+
+A Faraday middleware for params filtering in logs.
+
+## Installation
+
+Add this line to your application's Gemfile:
+
+```ruby
+gem "faraday-log-filter", github: "westfieldlabs/faraday-log-filter"
+```
+
+And then execute:
+
+```bash
+$ bundle install
+```
+
+## Usage
+
+Once required, the logger can be added to any Faraday connection by inserting
+it into your connection's request/response stack:
+
+```ruby
+connection = Faraday.new(url: "http://foo.com") do |faraday|
+  faraday.request  :url_encoded
+  faraday.response :log_filter, nil, 
+    filter: [:param1, param2: :truncate], 
+    log_options: { bodies: false, headers: true }
+end
+```
+
+By default, the Faraday::LogFilter will log to STDOUT. If this is not your
+desired log location, simply provide any Logger-compatible object as a
+parameter to the middleware definition:
+
+```ruby
+faraday.response :log_filter, Rails.logger, filter: filter: [:param1, param2: :truncate]
+```
+
+### Example output
+
+#### Request logging
+
+Log output for the request-portion of an HTTP interaction:
+
+```plain
+GET http://sushi.com/temaki?param1=[FILTERED]&param2=12345
+```

--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 A Faraday middleware for params filtering in logs.
 
+[![Code Climate](https://codeclimate.com/github/westfieldlabs/faraday-log-filter/badges/gpa.svg)](https://codeclimate.com/github/westfieldlabs/faraday-log-filter)
+[![Build Status](https://travis-ci.org/westfieldlabs/faraday-log-filter.svg?branch=master)](https://travis-ci.org/westfieldlabs/faraday-log-filter)
 ## Installation
 
 Add this line to your application's Gemfile:

--- a/Rakefile
+++ b/Rakefile
@@ -1,0 +1,6 @@
+require "bundler/gem_tasks"
+require "rspec/core/rake_task"
+
+RSpec::Core::RakeTask.new(:spec)
+
+task(default: :spec)

--- a/faraday-log-filter.gemspec
+++ b/faraday-log-filter.gemspec
@@ -20,5 +20,6 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency "faraday", "~> 0.8"
 
   spec.add_development_dependency "bundler", "~> 1.12"
+  spec.add_development_dependency "rake", "~> 12.0"
   spec.add_development_dependency "rspec", "~> 3.0"
 end

--- a/faraday-log-filter.gemspec
+++ b/faraday-log-filter.gemspec
@@ -1,19 +1,16 @@
-# coding: utf-8
 lib = File.expand_path("../lib", __FILE__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 require "faraday/log_filter/version"
 
 Gem::Specification.new do |spec|
-  spec.name = "faraday-log_filter"
+  spec.name = "faraday-log-filter"
   spec.version = Faraday::LogFilter::VERSION
   spec.authors = ["Westfield Labs"]
   spec.email = [""]
 
   spec.summary = "A way to filter request params in logger for Faraday."
-  spec.description = %(
-    A Faraday middleware for params filtering in logs.
-  )
-  spec.homepage = ""
+  spec.description = "A Faraday middleware for params filtering in logs."
+  spec.homepage = "https://github.com/westfieldlabs/faraday-log-filter"
 
   spec.files = `git ls-files -z`.split("\x0").reject { |f|
     f.match(%r{^(test|spec|features)/})

--- a/faraday-log-filter.gemspec
+++ b/faraday-log-filter.gemspec
@@ -11,6 +11,7 @@ Gem::Specification.new do |spec|
   spec.summary = "A way to filter request params in logger for Faraday."
   spec.description = "A Faraday middleware for params filtering in logs."
   spec.homepage = "https://github.com/westfieldlabs/faraday-log-filter"
+  spec.license = "Apache 2.0"
 
   spec.files = `git ls-files -z`.split("\x0").reject { |f|
     f.match(%r{^(test|spec|features)/})

--- a/lib/faraday/log_filter.rb
+++ b/lib/faraday/log_filter.rb
@@ -1,0 +1,9 @@
+require "faraday/log_filter/version"
+require "faraday/log_filter/filter"
+require "faraday/log_filter/env"
+require "faraday/log_filter/middleware"
+
+module Faraday
+  module LogFilter
+  end
+end

--- a/lib/faraday/log_filter/env.rb
+++ b/lib/faraday/log_filter/env.rb
@@ -1,0 +1,46 @@
+require 'delegate'
+
+module Faraday
+  module LogFilter
+    class Env < SimpleDelegator
+      def initialize(env, params_filter=[])
+        super env
+        @filter = Filter.new(params_filter)
+      end
+
+      def headers
+        Array(response_headers).map { |k, v| "#{k}: #{v.inspect}" }.join("\n")
+      end
+
+      def http_verb
+        __getobj__.method
+      end
+
+      def dump_url
+        @filter.filter_url(url).to_s
+      end
+
+      def dump_body
+        if self[:body].respond_to?(:to_str)
+          self[:body].to_str
+        else
+          pretty_inspect(self[:body])
+        end
+      end
+
+      def status
+        super.to_s
+      end
+
+      def has_body?
+        !!self[:body]
+      end
+
+      private
+      def pretty_inspect(body)
+        require 'pp' unless body.respond_to?(:pretty_inspect)
+        body.pretty_inspect
+      end
+    end
+  end
+end

--- a/lib/faraday/log_filter/filter.rb
+++ b/lib/faraday/log_filter/filter.rb
@@ -1,0 +1,42 @@
+module Faraday
+  module LogFilter
+    class Filter
+      def initialize(params_to_filter)
+        params_to_filter = Array(params_to_filter)
+        @params_to_truncate = params_to_filter.last.is_a?(Hash) ? params_to_filter.pop : {}
+        @params_to_filter   = params_to_filter | @params_to_truncate.keys
+      end
+
+      def filter_url(url)
+        url.query = filtered_query_for(url).map { |params| params.join("=") }.join("&")
+
+        url
+      end
+
+      private
+
+      def filtered_query_for(url)
+        filter(CGI::parse(url.query.to_s))
+      end
+
+      def filter(params)
+        params.map do |param, value|
+          [
+            param,
+            filter_or_truncate_param(param, value)
+          ]
+        end.to_h
+      end
+
+      def in_filter_list?(param)
+        @params_to_filter.include? param.to_sym
+      end
+
+      def filter_or_truncate_param(param, value)
+        return value unless in_filter_list?(param)
+
+        @params_to_truncate[param.to_sym] ? value.first[0..4] : "[FILTERED]"
+      end
+    end
+  end
+end

--- a/lib/faraday/log_filter/middleware.rb
+++ b/lib/faraday/log_filter/middleware.rb
@@ -1,0 +1,59 @@
+require "faraday"
+require 'forwardable'
+
+module Faraday
+  module LogFilter
+    class Middleware < Faraday::Response::Middleware
+      extend Forwardable
+
+      DEFAULT_OPTIONS = { headers: true, bodies: false }
+
+      def initialize(app, logger = nil, options = {})
+        super(app)
+        @logger = logger || begin
+          require 'logger'
+          ::Logger.new(STDOUT)
+        end
+        @options = DEFAULT_OPTIONS.merge(Hash(options[:log_options]))
+        @filter  = Array(options[:filter])
+      end
+
+      def_delegators :@logger, :debug, :info, :warn, :error, :fatal
+
+      def call(env)
+        env = Env.new(env, @filter)
+
+        info "#{env.http_verb.upcase} #{env.dump_url}"
+        debug('request') { env.headers } if log_headers?(:request)
+        debug('request') { env.dump_body } if env.has_body? && log_body?(:request)
+        super
+      end
+
+      def on_complete(env)
+        env = Env.new(env, @filter)
+
+        info('Status') { env.status }
+        debug('response') { env.headers } if log_headers?(:response)
+        debug('response') { env.dump_body } if env.has_body? && log_body?(:response)
+      end
+
+      private
+
+      def log_headers?(type)
+        return @options[:headers][type] if @options[:headers].is_a?(Hash)
+
+        @options[:headers]
+      end
+
+      def log_body?(type)
+        return @options[:bodies][type] if @options[:bodies].is_a?(Hash)
+
+        @options[:bodies]
+      end
+    end
+  end
+end
+
+Faraday::Response.register_middleware(
+  log_filter: Faraday::LogFilter::Middleware
+)

--- a/lib/faraday/log_filter/version.rb
+++ b/lib/faraday/log_filter/version.rb
@@ -1,0 +1,5 @@
+module Faraday
+  module LogFilter
+    VERSION = "0.1.0".freeze
+  end
+end

--- a/spec/faraday/log_filter/env_spec.rb
+++ b/spec/faraday/log_filter/env_spec.rb
@@ -1,0 +1,83 @@
+require "spec_helper"
+require 'uri'
+describe Faraday::LogFilter::Env do
+  subject { described_class.new(env) }
+  let(:env) { double('Env') }
+
+  describe "#has_body?" do
+    context "when env has body" do
+      let(:env) { {body: "content" } }
+
+      it { is_expected.to have_body }
+    end
+
+    context "when env has no body" do
+      let(:env) { {} }
+
+      it { is_expected.not_to have_body }
+    end
+  end
+
+  describe "#dump_url" do
+    let(:url) { URI("http://google.com?param=value") }
+    let(:env) { double(url: url) }
+
+    it "returns the env url as string" do
+      expect(subject.dump_url).to eq("http://google.com?param=value")
+    end
+
+    it "filters the url params" do
+      expect_any_instance_of(Faraday::LogFilter::Filter).to receive(:filter_url).with(url)
+
+      subject.dump_url
+    end
+  end
+
+  describe "#dump_body" do
+    context "when body content is a string" do
+      let(:env) { {body: "some content"} }
+
+      it "returns the body content" do
+        expect(subject.dump_body).to eq "some content"
+      end
+    end
+
+    context "when body content is not a string" do
+      let(:body) { {foo: "bar", baz: "zaz"} }
+      let(:env) { {body: body} }
+
+      it "returns the body content" do
+        require 'pp'
+        expect(subject.dump_body).to eq body.pretty_inspect
+      end
+    end
+  end
+
+  describe "#headers" do
+    let(:headers) do
+      {
+        AUTHENTICATON: 'Bearer foo',
+        Accept: 'application/json'
+      }
+    end
+    let(:env) { double('Env', response_headers: headers) }
+
+    it "returns all headers as string" do
+      expect(subject.headers).to eq "AUTHENTICATON: \"Bearer foo\"\nAccept: \"application/json\""
+    end
+  end
+
+  describe "#status" do
+    let(:env) { double('Env', status: 200) }
+    it "return status as string" do
+      expect(subject.status).to eq "200"
+    end
+  end
+
+  describe "#http_verb" do
+    let(:env) { double("Env", method: "POST") }
+    it "returns env method" do
+      expect(subject.http_verb).to eq("POST")
+    end
+  end
+end

--- a/spec/faraday/log_filter/filter_spec.rb
+++ b/spec/faraday/log_filter/filter_spec.rb
@@ -1,0 +1,17 @@
+require "spec_helper"
+
+describe Faraday::LogFilter::Filter do
+  describe "#filter_url" do
+    subject { described_class.new([:foo, token: :truncate, api_key: :truncate]) }
+
+    let(:url) do
+      URI("http://foo.bar?token=sometoken&format=json&api_key=12345677890&foo=bar")
+    end
+
+    it "filters out one of the parameters and truncates the other" do
+      expect(subject.filter_url(url)).to eq(
+        URI("http://foo.bar?token=somet&format=json&api_key=12345&foo=[FILTERED]")
+      )
+    end
+  end
+end

--- a/spec/faraday/log_filter/middleware_spec.rb
+++ b/spec/faraday/log_filter/middleware_spec.rb
@@ -1,0 +1,81 @@
+require "spec_helper"
+
+require "logger"
+require "stringio"
+
+describe Faraday::LogFilter::Middleware do
+  let(:log) { StringIO.new }
+  let(:logger) { Logger.new(log) }
+
+  it "logs with the filtered params" do
+    connection(logger, filter: [:api]).get("/temaki?api=122435")
+    log.rewind
+    expect(log.read).to include("api=[FILTERED]")
+  end
+
+  it "logs the request method at an INFO level" do
+    connection(logger).get("/temaki?api=123456")
+    log.rewind
+    expect(log.read).to match(/\bINFO\b.+\bGET\b/)
+  end
+
+  it "logs the request URI at an INFO level" do
+    connection(logger).get("/temaki?api=123456")
+    log.rewind
+    expect(log.read).to match(%r{\bINFO\b.+\bhttp://sushi.com/temaki\b})
+  end
+
+  it "logs a response status code at an INFO level" do
+    connection(logger).get("/temaki")
+    log.rewind
+    expect(log.read).to match(/INFO.+Status: 200\b/)
+  end
+
+  it "doesn't logs request's body" do
+    connection(logger).post("/nigirizushi")
+    log.rewind
+    expect(log.readlines.join).not_to include('DEBUG -- response: {"id":"1"}')
+  end
+
+  it "logs the request's headers at DEBUG level" do
+    connection(logger).post('/nigirizushi')
+    log.rewind
+
+    expect(log.readlines.join).to include('DEBUG -- response: Content-Type: "application/json"')
+  end
+
+  context "when set body log to true" do
+    it "logs the request's body at DEBUG level" do
+      connection(logger, log_options: { bodies: true }).post('/nigirizushi')
+      log.rewind
+
+      expect(log.readlines.join).to include('DEBUG -- response: {"id":"1"}')
+    end
+  end
+
+  context "when set headers log to false" do
+    it "doesn't log the request's headers" do
+      connection(logger, log_options: { headers: false }).post('/nigirizushi')
+      log.rewind
+
+      expect(log.readlines.join).not_to include('DEBUG -- response: Content-Type: "application/json"')
+    end
+  end
+
+  private
+
+  def connection(logger = nil, config={})
+    Faraday.new(url: "http://sushi.com") do |builder|
+      builder.request(:url_encoded)
+      builder.response(:log_filter, logger, config)
+      builder.adapter(:test) do |stub|
+        stub.get("/temaki") do
+          [200, { "Content-Type" => "text/plain" }, "temaki"]
+        end
+        stub.post("/nigirizushi") do
+          [200, { "Content-Type" => "application/json" }, "{\"id\":\"1\"}"]
+        end
+      end
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,0 +1,8 @@
+lib = File.expand_path("../lib", __FILE__)
+$LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
+
+require "faraday/log_filter"
+
+RSpec.configure do |config|
+  config.order = :random
+end


### PR DESCRIPTION
Faraday middleware, to filter requests params in logger

set configuration:
```ruby
connection = Faraday.new(url: "http://foo.com") do |faraday|
  faraday.request  :url_encoded
  faraday.response :log_filter, logger, filter: [:param1, param2: :truncate]
end
```


`http://some-endpoint.com?param1=some-value&param2=1234567890&param3=foo` 
will show 
`http://some-endpoint.com?param1=[FILTERED]&param2=12345&param3=foo`

### TODO:

- [x] Add license